### PR TITLE
Fix WLED power state retrieval bug

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -407,7 +407,8 @@ class WLED:
         Returns:
             boolean: True is "On", False is "Off"
         """
-        return await self.get_state()["on"]
+        state = await self.get_state()
+        return state["on"]
 
     async def get_segments(self):
         """


### PR DESCRIPTION
## Summary
- correct asynchronous call when fetching WLED power state

## Testing
- `pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68416de412e48332b379201438740309