### PR TITLE
Fix WLED brightness clamping

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -447,7 +447,7 @@ class WLED:
             brightness (int): The brightness value between 0-255
         """
         # cast to int and clamp to range
-        brightness = max(0, max(int(brightness), 255))
+        brightness = max(0, min(int(brightness), 255))
         bri = {"bri": brightness}
 
         await WLED._wled_request(


### PR DESCRIPTION
## Summary
- clamp brightness values for WLED devices properly

## Testing
- `uv run pytest -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684172ae0a4c8332ba481947ae0fd7d6