### PR TITLE
Add timeout to ledfx_is_alive

### DIFF
--- a/tests/test_utilities/test_utils.py
+++ b/tests/test_utilities/test_utils.py
@@ -198,6 +198,7 @@ class EnvironmentCleanup:
             if response.status_code == 200:
                 # LedFx has returned a response, so it is running, but likely still hydrating the schema
                 # We will wait until it is fully hydrated
+                start_time = time.time()
                 while True:
                     old_schema = requests.get(
                         f"http://{SERVER_PATH}/api/schema", timeout=1
@@ -208,6 +209,8 @@ class EnvironmentCleanup:
                     )
                     if old_schema.json() == new_schema.json():
                         break
+                    if time.time() - start_time > 5:
+                        return False
                 time.sleep(2)
                 return True
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
## Summary
- avoid hanging if `/api/schema` never stabilises by using a 5s timeout

## Testing
- `pytest tests/test_utilities/test_utils.py::EnvironmentCleanup::ledfx_is_alive -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684175953d5883328da95ab9a6ed4b5e