### PR TITLE
Enable pytest slowest durations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ hue = [
 ledfx = "ledfx.__main__:main"
 ledfx-loopback-install = "loopback.__main__:copy_lib"
 [tool.pytest.ini_options]
-addopts = "tests"
+addopts = "--durations=10 tests"
 testpaths = "tests"
 norecursedirs = [
     "dist",


### PR DESCRIPTION
## Summary
- add `--durations=10` in pytest configuration
- ensure test output lists 10 slowest tests

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_684257bbcbf48332b22a868d1feef3b7